### PR TITLE
fix build issues + reenable logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,17 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1</version>
+            <version>1.1.6</version>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
         </dependency>
         <dependency>
             <groupId>ca.juliusdavies</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <java.dir>${basedir}/src/main/java</java.dir>
         <project.home>${basedir}</project.home>
         <surefire.jvm.args>ea</surefire.jvm.args>
-        <smversion>1.6</smversion>
+        <smversion>1.7</smversion>
         <exclude.tests>nothing-to-exclude</exclude.tests>
         <!--<exclude.test2>nothing-to-exclude</exclude.test2>-->
     </properties>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.3</version>
+            <version>3.1</version>
             <type>maven-plugin</type>
         </dependency>
         <dependency>
@@ -328,13 +328,13 @@
 
                 <executions>
                     <!-- ... -->
-                    <!--<execution>-->
-                        <!--<id>compile</id>-->
-                        <!--<phase>compile</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>compile</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
                     <!--<execution>-->
                         <!--<id>test-clojure</id>-->
                         <!--<phase>test</phase>-->
@@ -379,11 +379,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
+                <version>3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.1</version>
+            <version>3.3</version>
             <type>maven-plugin</type>
         </dependency>
         <dependency>
@@ -379,7 +379,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/clojure/edu/umass/cs/runner/dashboard/Dashboard.clj
+++ b/src/main/clojure/edu/umass/cs/runner/dashboard/Dashboard.clj
@@ -1,5 +1,3 @@
-(comment
-
 (ns edu.umass.cs.runner.dashboard.Dashboard
   (:gen-class
     :name edu.umass.cs.runner.dashboard.Dashboard
@@ -95,5 +93,4 @@
   [& args]
   ;; This is called when we have the Runner running a survey in another process, and we want to monitor it in a
   ;; separate process.
-  )
   )

--- a/src/main/clojure/edu/umass/cs/runner/utils/response_util.clj
+++ b/src/main/clojure/edu/umass/cs/runner/utils/response_util.clj
@@ -5,7 +5,8 @@
   (:import
     (edu.umass.cs.surveyman.analyses SurveyResponse IQuestionResponse OptTuple)
     (edu.umass.cs.surveyman.input AbstractParser)
-    (edu.umass.cs.surveyman.qc RandomRespondent RandomRespondent$AdversaryType QCMetrics)
+    (edu.umass.cs.surveyman.qc QCMetrics)
+    (edu.umass.cs.surveyman.qc.respondents RandomRespondent RandomRespondent$AdversaryType)
     (edu.umass.cs.surveyman.survey Survey Question SurveyDatum)
     (java.util List Map))
   )

--- a/src/main/clojure/edu/umass/cs/runner/utils/response_util.clj
+++ b/src/main/clojure/edu/umass/cs/runner/utils/response_util.clj
@@ -1,5 +1,3 @@
-(comment
-
 (ns
   ^{:author etosch
     :doc "Utilities for manipulating survey responses for data analysis."}
@@ -7,7 +5,7 @@
   (:import
     (edu.umass.cs.surveyman.analyses SurveyResponse IQuestionResponse OptTuple)
     (edu.umass.cs.surveyman.input AbstractParser)
-    (edu.umass.cs.surveyman.qc.respondents RandomRespondent RandomRespondent$AdversaryType QCMetrics)
+    (edu.umass.cs.surveyman.qc RandomRespondent RandomRespondent$AdversaryType QCMetrics)
     (edu.umass.cs.surveyman.survey Survey Question SurveyDatum)
     (java.util List Map))
   )
@@ -199,6 +197,4 @@
   (contains? (set (flatten (map (fn [^IQuestionResponse qr] (map #(.c %) (.getOpts qr))) (get-true-responses sr))))
     c
     )
-  )
-
   )

--- a/src/main/java/edu/umass/cs/runner/Record.java
+++ b/src/main/java/edu/umass/cs/runner/Record.java
@@ -11,7 +11,6 @@ import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import edu.umass.cs.surveyman.utils.Gensym;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
@@ -19,7 +18,7 @@ import java.util.*;
 
 public class Record implements Serializable {
 
-//    final private static Logger LOGGER = LogManager.getLogger("Runner");
+    final private static Logger LOGGER = Runner.LOGGER;
     final private static Gensym gensym = new Gensym(String.format("rec_%d", System.currentTimeMillis()));
 
     public String outputFileName;
@@ -45,7 +44,7 @@ public class Record implements Serializable {
         objectOutputStream.writeObject(this);
         objectOutputStream.close();
         fileOutputStream.close();
-//        LOGGER.info("Wrote record data to " + serializedFileName);
+        LOGGER.info("Wrote record data to " + serializedFileName);
         return serializedFileName;
     }
 
@@ -75,9 +74,9 @@ public class Record implements Serializable {
         this.qcMetrics = qcMetrics;
         try {
             boolean madeOutDir = (new File(AbstractLibrary.OUTDIR)).mkdir();
-//            LOGGER.debug(String.format("Made new ouput directory: %b", madeOutDir));
+            LOGGER.debug(String.format("Made new ouput directory: %b", madeOutDir));
             boolean madeLogdDir = (new File("logs")).mkdir();
-//            LOGGER.debug(String.format("Made new logs directory: %b", madeLogdDir));
+            LOGGER.debug(String.format("Made new logs directory: %b", madeLogdDir));
             File outfile = new File(String.format("%s%s%s_%s_%s.csv"
                     , AbstractLibrary.OUTDIR
                     , AbstractLibrary.fileSep
@@ -85,7 +84,7 @@ public class Record implements Serializable {
                     , qcMetrics.survey.sid
                     , AbstractLibrary.TIME));
             boolean madeOutFile = outfile.createNewFile();
-//            LOGGER.debug(String.format("Made new outputfile %s: %b", outfile, madeOutFile));
+            LOGGER.debug(String.format("Made new outputfile %s: %b", outfile, madeOutFile));
             File htmlFileName = new File(String.format("%s%slogs%s%s_%s_%s.html"
                     , (new File("")).getAbsolutePath()
                     , AbstractLibrary.fileSep
@@ -96,13 +95,13 @@ public class Record implements Serializable {
             boolean createdNewFile = false;
             if (! htmlFileName.exists())
                 createdNewFile = htmlFileName.createNewFile();
-//            LOGGER.debug(String.format("Created new HTML file %s: %b", htmlFileName.getAbsolutePath(), createdNewFile));
+            LOGGER.debug(String.format("Created new HTML file %s: %b", htmlFileName.getAbsolutePath(), createdNewFile));
             File recordDir = new File(this.RECORDDIR);
             boolean madeRecordDirs = false;
             if (! recordDir.exists())
                 madeRecordDirs = recordDir.mkdirs();
-//            LOGGER.debug(String.format("Created new record directory %s: %b", recordDir.getAbsolutePath(),
-//                    madeRecordDirs));
+            LOGGER.debug(String.format("Created new record directory %s: %b", recordDir.getAbsolutePath(),
+                    madeRecordDirs));
             this.outputFileName = outfile.getCanonicalPath();
             this.htmlFileName = htmlFileName.getCanonicalPath();
         } catch (IOException e) {
@@ -117,16 +116,16 @@ public class Record implements Serializable {
         this.classifier = qcMetrics.classifier;
         this.alpha = qcMetrics.classifier.alpha;
         this.expectedCost = computeExpectedCost();
-//        LOGGER.info(String.format("New record with id (%s) created for survey %s (%s)."
-//                , rid
-//                , survey.sourceName
-//                , survey.sid
-//        ));
+        LOGGER.info(String.format("New record with id (%s) created for survey %s (%s)."
+                , rid
+                , survey.sourceName
+                , survey.sid
+        ));
         try {
             this.serializeRecord();
         } catch (IOException io) {
-//            LOGGER.warn(String.format("Attempt to serialize record %s in constructor failed.,", this.rid));
-//            LOGGER.warn(io);
+            LOGGER.warn(String.format("Attempt to serialize record %s in constructor failed.,", this.rid));
+            LOGGER.warn(io);
         }
     }
 
@@ -139,7 +138,7 @@ public class Record implements Serializable {
                    AbstractLibrary.FEDMINWAGE *
                    n;
         } catch (SurveyException se) {
-//            LOGGER.warn(se);
+            LOGGER.warn(se);
         } catch (Exception e) {
             System.out.println(StringUtils.join(this.library.props.propertyNames(), "\n"));
         }
@@ -165,7 +164,7 @@ public class Record implements Serializable {
         try {
             this.serializeRecord();
         } catch (IOException io) {
-//            LOGGER.warn("Attempted to serialize record:\n"+io);
+            LOGGER.warn("Attempted to serialize record:\n"+io);
         }
     }
 
@@ -255,34 +254,34 @@ public class Record implements Serializable {
                     htmlFileEqual = this.htmlFileName.equals(that.htmlFileName),
                     backendTypeEqual = this.backendType.equals(that.backendType);
             if (!outputFileEqual) {
-//                LOGGER.debug(String.format("Record output filenames not equal (%s vs. %s)", this.outputFileName, that.outputFileName));
+                LOGGER.debug(String.format("Record output filenames not equal (%s vs. %s)", this.outputFileName, that.outputFileName));
                 return false;
             } else if (!surveyEqual) {
-//                LOGGER.debug(String.format("Surveys not equal (%s vs %s)", this.survey, that.survey));
+                LOGGER.debug(String.format("Surveys not equal (%s vs %s)", this.survey, that.survey));
                 return false;
             } else if (!libraryEqual) {
-//                LOGGER.debug(String.format("Libraries not equal (%s vs. %s)", this.library, that.library));
+                LOGGER.debug(String.format("Libraries not equal (%s vs. %s)", this.library, that.library));
                 return false;
             } else if (!classifierEqual) {
-//                LOGGER.debug(String.format("Classifiers not equal: (%s vs. %s)", this.classifier, that.classifier));
+                LOGGER.debug(String.format("Classifiers not equal: (%s vs. %s)", this.classifier, that.classifier));
                 return false;
             } else if (!alphaEqual) {
-//                LOGGER.debug(String.format("Alpha not equal (%f vs. %f)", this.alpha, that.alpha));
+                LOGGER.debug(String.format("Alpha not equal (%f vs. %f)", this.alpha, that.alpha));
                 return false;
             } else if (!ridEqual){
-//                LOGGER.debug(String.format("Record ids not equal (%s vs. %s)", this.rid, that.rid));
+                LOGGER.debug(String.format("Record ids not equal (%s vs. %s)", this.rid, that.rid));
                 return false;
             } else if (!numResponsesEqual) {
-//                LOGGER.debug(String.format("Number of responses not equal (%d vs. %d)", thisNumResponses, thatNumResponses));
+                LOGGER.debug(String.format("Number of responses not equal (%d vs. %d)", thisNumResponses, thatNumResponses));
                 return false;
             } else if (!numTasksEqual) {
-//                LOGGER.debug(String.format("Number of tasks not equal (%d vs. %d)", thisNumTasks, thatNumTasks));
+                LOGGER.debug(String.format("Number of tasks not equal (%d vs. %d)", thisNumTasks, thatNumTasks));
                 return false;
             } else if (!htmlFileEqual) {
-//                LOGGER.debug(String.format("HTML files not equal (%s vs. %s)", this.htmlFileName, that.htmlFileName));
+                LOGGER.debug(String.format("HTML files not equal (%s vs. %s)", this.htmlFileName, that.htmlFileName));
                 return false;
             } else if (!backendTypeEqual) {
-//                LOGGER.debug(String.format("Backend type not equal (%s vs. %s)", this.backendType.name(), that.backendType.name()));
+                LOGGER.debug(String.format("Backend type not equal (%s vs. %s)", this.backendType.name(), that.backendType.name()));
                 return false;
             } else return true;
         } else return false;

--- a/src/main/java/edu/umass/cs/runner/ResponseWriter.java
+++ b/src/main/java/edu/umass/cs/runner/ResponseWriter.java
@@ -42,7 +42,7 @@ public class ResponseWriter {
             s.append(String.format("%s%s", sep, AbstractParser.CORRELATION));
 
         s.append("\r\n");
-//        Runner.LOGGER.info("headers:" + s.toString());
+        Runner.LOGGER.info("headers:" + s.toString());
         return s.toString();
     }
 

--- a/src/main/java/edu/umass/cs/runner/Runner.java
+++ b/src/main/java/edu/umass/cs/runner/Runner.java
@@ -24,11 +24,7 @@ import edu.umass.cs.surveyman.input.AbstractParser;
 import edu.umass.cs.surveyman.input.csv.CSVLexer;
 import edu.umass.cs.surveyman.input.csv.CSVParser;
 import edu.umass.cs.surveyman.input.json.JSONParser;
-import edu.umass.cs.surveyman.qc.QCMetrics;
-import edu.umass.cs.surveyman.qc.classifiers.AbstractClassifier;
-import edu.umass.cs.surveyman.qc.classifiers.AllClassifier;
-import edu.umass.cs.surveyman.qc.classifiers.Classifiers;
-import edu.umass.cs.surveyman.qc.classifiers.ClusterClassifier;
+import edu.umass.cs.surveyman.qc.Classifier;
 import edu.umass.cs.surveyman.survey.Question;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
@@ -47,7 +43,7 @@ import java.util.*;
 
 public class Runner {
 
-//    public static final Logger LOGGER = LogManager.getLogger(Runner.class.getName());
+    public static final Logger LOGGER = LogManager.getLogger(Runner.class.getName());
     private static long timeSinceLastNotice = System.currentTimeMillis();
     public static KnownBackendType backendType;
     public static AbstractResponseManager responseManager;
@@ -136,8 +132,8 @@ public class Runner {
         for (ITask hit : record.getAllTasks()) {
             hiturl = surveyPoster.makeTaskURL(responseManager, hit);
             responsesAdded = responseManager.addResponses(survey, hit);
-//            if (responsesAdded > 0)
-//                LOGGER.debug(String.format("Added %d responses", responsesAdded));
+            if (responsesAdded > 0)
+                LOGGER.debug(String.format("Added %d responses", responsesAdded));
         }
 
         msg = String.format("Polling for responses for Tasks at %s (%d total; %d valid)"
@@ -147,7 +143,7 @@ public class Runner {
 
         if (System.currentTimeMillis() - timeSinceLastNotice > 1000000) {
             System.out.println(msg);
-//            LOGGER.info(msg);
+            LOGGER.info(msg);
             timeSinceLastNotice = System.currentTimeMillis();
         }
 
@@ -226,27 +222,27 @@ public class Runner {
                     sr.getSrid());
             if (!sr.isRecorded()) {
                 PrintWriter bw = null;
-//                LOGGER.info("Writing " + sr.getSrid() + "...");
+                LOGGER.info("Writing " + sr.getSrid() + "...");
                 try {
-//                    LOGGER.info(record.outputFileName);
+                    LOGGER.info(record.outputFileName);
                     File f = new File(record.outputFileName);
                     bw = new PrintWriter(new FileWriter(f, true));
                     if (! f.exists() || f.length()==0)
                         bw.print(ResponseWriter.outputHeaders(survey, record.library.getBackendHeaders()));
                     String txt = ResponseWriter.outputSurveyResponse(survey, sr);
-//                    LOGGER.info(txt);
+                    LOGGER.info(txt);
                     bw.print(txt);
                     bw.flush();
                     bw.close();
                     sr.setRecorded(true);
                 } catch (IOException ex) {
-//                    LOGGER.info(ex.getMessage());
-//                    LOGGER.warn(ex);
+                    LOGGER.info(ex.getMessage());
+                    LOGGER.warn(ex);
                 } finally {
                     try {
                         if (bw != null) bw.close();
                     } catch (Exception ex) {
-//                        LOGGER.warn(ex);
+                        LOGGER.warn(ex);
                     }
                 }
             }
@@ -276,7 +272,7 @@ public class Runner {
                     } catch (SurveyException e) {
                         e.printStackTrace();
                     } catch (NullPointerException npe) {
-//                        LOGGER.warn(npe);
+                        LOGGER.warn(npe);
                     }
                 } while (!interrupt.getInterrupt());
                     // clean up
@@ -303,7 +299,7 @@ public class Runner {
             do {
                 // Log every 5 times this thing is called:
                 if (numTimesCalled % 5 == 0) {
-//                    LOGGER.info(String.format("Runner Thread called %d times.", numTimesCalled));
+                    LOGGER.info(String.format("Runner Thread called %d times.", numTimesCalled));
                     numTimesCalled++;
                 }
                 if (!interrupt.getInterrupt()) {
@@ -319,7 +315,7 @@ public class Runner {
 
             String msg = "Fatal error: " + e.getMessage() + "\nExiting...";
             System.err.println(msg);
-//            LOGGER.fatal(e);
+            LOGGER.fatal(e);
             interrupt.setInterrupt(true,"Error detected in edu.umass.cs.runner.Runner.run",e.getStackTrace()[1]);
 
         } finally {
@@ -410,7 +406,7 @@ public class Runner {
                         exit(abstractResponseManager, record);
                         return;
                     } else if (choice==stopDashboardChoice) {
-//                        LOGGER.info("User cancelling dashboard service.");
+                        LOGGER.info("User cancelling dashboard service.");
                         try {
                             if (dashboardServer!=null)
                                 dashboardServer.stop();
@@ -427,34 +423,6 @@ public class Runner {
         };
     }
 
-    public static AbstractClassifier getClassifier(
-            String name,
-            Survey survey,
-            boolean smoothing,
-            double alpha,
-            int numClusters
-    ) {
-        switch (Classifiers.valueOf(name)) {
-            case ALL:
-                return new AllClassifier(survey, smoothing, alpha, numClusters);
-            case CLUSTER:
-                return new ClusterClassifier(survey, smoothing, alpha, numClusters);
-            case ENTROPY:
-                break;
-            case LINEAR:
-                break;
-            case LPO:
-                break;
-            case MAHALANOBIS:
-                break;
-            case NIPS2010:
-                break;
-            case STACKED:
-                break;
-        }
-        return null;
-    }
-
     public static void runAll(
             String s,
             String sep,
@@ -464,6 +432,9 @@ public class Runner {
                    NoSuchMethodException,
                    IOException,
                    InterruptedException, SurveyException {
+        Classifier classifier = Classifier.valueOf(((String) ns.get("classifier")).toUpperCase());
+        boolean smoothing = Boolean.valueOf((String) ns.get("smoothing"));
+        double alpha = Double.valueOf((String) ns.get("alpha"));
         boolean breakoff = Boolean.valueOf((String) ns.get("breakoff"));
         boolean runDashboardp = Boolean.valueOf((String) ns.get("dashboard"));
         AbstractParser parser;
@@ -473,13 +444,6 @@ public class Runner {
             parser = new JSONParser(Slurpie.slurp(s));
         else throw new RuntimeException("Input files must have csv or json extensions.");
         Survey survey = parser.parse();
-        AbstractClassifier classifier = getClassifier(
-                ((String) ns.get("classifier")).toUpperCase(),
-                survey,
-                Boolean.valueOf((String) ns.get("smoothing")),
-                Double.valueOf((String) ns.get("alpha")),
-                2
-        );
         // Kind of a hack.
         if (!breakoff)
             for (Question q : survey.questions)
@@ -491,7 +455,7 @@ public class Runner {
 
     public static void runAll(
             Survey survey,
-            AbstractClassifier classifier,
+            Classifier classifier,
             boolean smoothing,
             double alpha,
             boolean runDashboardp)
@@ -502,7 +466,7 @@ public class Runner {
             InterruptedException
     {
         // create and store the record
-        final Record record = new Record(new QCMetrics(survey, classifier),  library, backendType);
+        final Record record = new Record(survey, library, classifier, smoothing, alpha, backendType);
         AbstractResponseManager.putRecord(survey, record);
         Runner.alpha = alpha;
         Runner.smoothing = smoothing;
@@ -520,7 +484,7 @@ public class Runner {
         while (record.getAllTasks().length==0) {}
         for (ITask task : record.getAllTasks())
             msg.append("\n\t" + surveyPoster.makeTaskURL(responseManager, task));
-//        LOGGER.info(msg.toString());
+        LOGGER.info(msg.toString());
         System.out.println(msg.toString());
         runner.join();
         responder.join();
@@ -532,14 +496,13 @@ public class Runner {
             Record record)
     {
         // TODO(etosch): make this more java-like in the future.
-//        IFn require = Clojure.var("clojure.core", "require");
-//        require.invoke(Clojure.read("edu.umass.cs.runner.dashboard.Dashboard"));
-//        IFn run = Clojure.var("edu.umass.cs.runner.dashboard.Dashboard", "-run");
-//        System.out.println(String.format(
-//                "To monitor the survey, navigate to:\n\thttp://localhost:%d/src/main/resources/debugger/Debug.html",
-//                (Long) Clojure.var("edu.umass.cs.runner.dashboard.Dashboard", "-getPort").invoke()));
-//        return (org.eclipse.jetty.server.Server) run.invoke(record);
-        return null;
+        IFn require = Clojure.var("clojure.core", "require");
+        require.invoke(Clojure.read("edu.umass.cs.runner.dashboard.Dashboard"));
+        IFn run = Clojure.var("edu.umass.cs.runner.dashboard.Dashboard", "-run");
+        System.out.println(String.format(
+                "To monitor the survey, navigate to:\n\thttp://localhost:%d/src/main/resources/debugger/Debug.html",
+                (Long) Clojure.var("edu.umass.cs.runner.dashboard.Dashboard", "-getPort").invoke()));
+        return (org.eclipse.jetty.server.Server) run.invoke(record);
     }
 
     public static void main(
@@ -577,11 +540,11 @@ public class Runner {
                 Server.endServe();
 
             String msg = String.format("Shutting down. Execute this program with args %s to repeat.", Arrays.toString(args));
-//            LOGGER.info(msg);
+            LOGGER.info(msg);
 
         } catch (ArgumentParserException e) {
             System.err.println("FAILURE: "+e.getMessage());
-//            LOGGER.fatal(e);
+            LOGGER.fatal(e);
             argumentParser.printHelp();
         }
     }

--- a/src/main/java/edu/umass/cs/runner/samples/JudgementTaskRunner.java
+++ b/src/main/java/edu/umass/cs/runner/samples/JudgementTaskRunner.java
@@ -4,7 +4,7 @@ import edu.umass.cs.runner.Runner;
 import edu.umass.cs.runner.system.backend.KnownBackendType;
 import edu.umass.cs.runner.system.backend.known.localhost.Server;
 import edu.umass.cs.runner.system.backend.known.localhost.server.WebServerException;
-import edu.umass.cs.surveyman.qc.Classifier;
+import edu.umass.cs.surveyman.SurveyMan;
 import edu.umass.cs.surveyman.samples.JudgementTask;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
@@ -24,7 +24,7 @@ public class JudgementTaskRunner {
         Runner.init(KnownBackendType.LOCALHOST);
         Server.startServe();
         Survey survey = JudgementTask.makeSurvey();
-        Runner.runAll(survey, Classifier.LOG_LIKELIHOOD, false, 0.05, true);
+        Runner.runAll(survey, SurveyMan.resolveClassifier(survey, "lpo", 2, 0.05, false), false, 0.05, true);
         Server.endServe();
     }
 }

--- a/src/main/java/edu/umass/cs/runner/samples/JudgementTaskRunner.java
+++ b/src/main/java/edu/umass/cs/runner/samples/JudgementTaskRunner.java
@@ -4,6 +4,7 @@ import edu.umass.cs.runner.Runner;
 import edu.umass.cs.runner.system.backend.KnownBackendType;
 import edu.umass.cs.runner.system.backend.known.localhost.Server;
 import edu.umass.cs.runner.system.backend.known.localhost.server.WebServerException;
+import edu.umass.cs.surveyman.qc.Classifier;
 import edu.umass.cs.surveyman.samples.JudgementTask;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
@@ -23,7 +24,7 @@ public class JudgementTaskRunner {
         Runner.init(KnownBackendType.LOCALHOST);
         Server.startServe();
         Survey survey = JudgementTask.makeSurvey();
-        Runner.runAll(survey, Runner.getClassifier("lpo", survey, false, 0.05, 2), false, 0.05, true);
+        Runner.runAll(survey, Classifier.LOG_LIKELIHOOD, false, 0.05, true);
         Server.endServe();
     }
 }

--- a/src/main/java/edu/umass/cs/runner/system/BoxedBool.java
+++ b/src/main/java/edu/umass/cs/runner/system/BoxedBool.java
@@ -11,7 +11,7 @@ public class BoxedBool {
         String source = "";
         if (caller!=null)
             source = caller.getMethodName();
-//        Runner.LOGGER.info(String.format("Interrupt in %s: %s", source, reason));
+        Runner.LOGGER.info(String.format("Interrupt in %s: %s", source, reason));
         this.interrupt = bool;
     }
     public void setInterrupt(boolean bool, String reason) {

--- a/src/main/java/edu/umass/cs/runner/system/QuestionResponse.java
+++ b/src/main/java/edu/umass/cs/runner/system/QuestionResponse.java
@@ -85,9 +85,7 @@ public class QuestionResponse implements IQuestionResponse {
             this.q = s.getQuestionById(response.getString("quid"));
             this.indexSeen = response.getInt("qpos");
             // do something
-            if (q.freetext) {
-//                Runner.LOGGER.warn("In freetext -- do something?");
-            }
+            if (q.freetext) Runner.LOGGER.warn("In freetext -- do something?");
             else {
                 SurveyDatum c = s.getQuestionById(q.id).getOptById(response.getString("oid"));
                 int optloc = response.getInt("opos");

--- a/src/main/java/edu/umass/cs/runner/system/SurveyResponse.java
+++ b/src/main/java/edu/umass/cs/runner/system/SurveyResponse.java
@@ -56,7 +56,7 @@ public class SurveyResponse extends edu.umass.cs.surveyman.analyses.SurveyRespon
         this.srid = wID;
     }
 
-    public SurveyResponse(edu.umass.cs.surveyman.analyses.SurveyResponse surveyResponse) {
+    public SurveyResponse(SurveyResponse surveyResponse) {
         this(surveyResponse.getSurvey(), surveyResponse.getSrid());
     }
 

--- a/src/main/java/edu/umass/cs/runner/system/SurveyResponse.java
+++ b/src/main/java/edu/umass/cs/runner/system/SurveyResponse.java
@@ -56,7 +56,7 @@ public class SurveyResponse extends edu.umass.cs.surveyman.analyses.SurveyRespon
         this.srid = wID;
     }
 
-    public SurveyResponse(SurveyResponse surveyResponse) {
+    public SurveyResponse(edu.umass.cs.surveyman.analyses.SurveyResponse surveyResponse) {
         this(surveyResponse.getSurvey(), surveyResponse.getSrid());
     }
 

--- a/src/main/java/edu/umass/cs/runner/system/backend/AbstractLibrary.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/AbstractLibrary.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 
 public abstract class AbstractLibrary implements Serializable {
 
-//    public static Logger LOGGER = Runner.LOGGER;
+    public static Logger LOGGER = Runner.LOGGER;
     public Properties props;
     public static final String fileSep = File.separator;
 
@@ -56,7 +56,7 @@ public abstract class AbstractLibrary implements Serializable {
             if (! new File(BONUS_DATA).exists())
                 new File(BONUS_DATA).createNewFile();
         } catch (IOException ex) {
-//            Runner.LOGGER.fatal(ex);
+            Runner.LOGGER.fatal(ex);
         }
     }
 
@@ -84,10 +84,10 @@ public abstract class AbstractLibrary implements Serializable {
             out.flush();
             out.close();
         } catch (FileNotFoundException e) {
-//            Runner.LOGGER.fatal(e);
+            Runner.LOGGER.fatal(e);
             System.exit(1);
         } catch (IOException io) {
-//            Runner.LOGGER.fatal(io);
+            Runner.LOGGER.fatal(io);
             System.exit(1);
         }
     }

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/LocalLibrary.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/LocalLibrary.java
@@ -22,8 +22,8 @@ public class LocalLibrary extends AbstractLibrary {
                 super.props = new Properties();
                 super.props.load(new FileReader(propertiesURL));
             } catch (FileNotFoundException e) {
-//                Runner.LOGGER.warn(e);
-//                Runner.LOGGER.info(e.getLocalizedMessage()+"\nUsing default value instead...");
+                Runner.LOGGER.warn(e);
+                Runner.LOGGER.info(e.getLocalizedMessage()+"\nUsing default value instead...");
                 init();
             } catch (IOException e) {
                 e.printStackTrace();
@@ -62,7 +62,7 @@ public class LocalLibrary extends AbstractLibrary {
                         case 1:
                             params = Slurpie.slurp("params.properties");
                             assert !params.isEmpty() : "params.properties is empty";
-//                            LOGGER.debug(params);
+                            LOGGER.debug(params);
                             fileWriter = new FileWriter(AbstractLibrary.PARAMS);
                             fileWriter.write(params);
                             init();
@@ -81,14 +81,14 @@ public class LocalLibrary extends AbstractLibrary {
                     }
                 }
             } catch (IOException e) {
-//                Runner.LOGGER.fatal(e);
+                Runner.LOGGER.fatal(e);
                 System.err.println(e.getMessage());
                 System.exit(1);
             } finally {
                 scanner.close();
             }
         }catch(IOException io){
-//            Runner.LOGGER.fatal(io);
+            Runner.LOGGER.fatal(io);
             System.err.println(io.getMessage());
             System.exit(1);
         }
@@ -109,9 +109,9 @@ public class LocalLibrary extends AbstractLibrary {
             if (thisBackendHeaders.equals(thatBackendHeaders))
                 return true;
             else {
-//                LOGGER.debug(String.format("Backend headers not equal (%s vs. %s)",
-//                        StringUtils.join(thisBackendHeaders, ","),
-//                        StringUtils.join(thatBackendHeaders, ",")));
+                LOGGER.debug(String.format("Backend headers not equal (%s vs. %s)",
+                        StringUtils.join(thisBackendHeaders, ","),
+                        StringUtils.join(thatBackendHeaders, ",")));
                 return false;
             }
         } else return false;

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/LocalResponseManager.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/LocalResponseManager.java
@@ -81,11 +81,7 @@ public class LocalResponseManager extends AbstractResponseManager {
     }
 
     @Override
-    public int addResponses(
-            Survey survey,
-            ITask task)
-            throws SurveyException
-    {
+    public int addResponses(Survey survey, ITask task) throws SurveyException {
         int botResponsesToAdd = 0, validResponsesToAdd = 0;
         Record r = null;
         try {
@@ -99,29 +95,7 @@ public class LocalResponseManager extends AbstractResponseManager {
             for (Server.IdResponseTuple tupe : tuples) {
                 SurveyResponse sr = parseResponse(tupe.id, tupe.xml, survey, r, null);
                 assert sr!=null;
-                boolean valid =
-                switch (r.classifier) {
-                    case ENTROPY:
-                        valid = QCMetrics.entropyClassification(
-                                survey,
-                                sr,
-                                new ArrayList<SurveyResponse>(r.getAllResponses()),
-                                r.smoothing,
-                                r.alpha
-                        );
-                        break;
-                    case LOG_LIKELIHOOD:
-                        valid = QCMetrics.logLikelihoodClassification(
-                                survey,
-                                sr,
-                                new ArrayList<SurveyResponse>(r.getAllResponses()),
-                                r.smoothing,
-                                r.alpha
-                        );
-                        break;
-                    default:
-                        throw new RuntimeException("Unknown classification metric: " + r.classifier.name());
-                }
+		boolean valid = r.classifier.classifyResponse(sr);
                 if (valid) {
                     r.addValidResponse(sr);
                     r.removeBotResponse(sr);

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/Server.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/Server.java
@@ -64,7 +64,7 @@ public class Server {
                             response = Slurpie.slurp(path);
                         } catch (IOException e) {
                             httpResponse.sendError(404, "Not Found");
-//                            Runner.LOGGER.warn(e);
+                            Runner.LOGGER.warn(e);
                             return;
                         }
                     }

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/server/WebServer.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/localhost/server/WebServer.java
@@ -68,7 +68,7 @@ public class WebServer {
                 LocalResponseManager.chill(5);
                 currentPort++;
                 e = exception;
-//                Runner.LOGGER.warn(e.getMessage());
+                Runner.LOGGER.warn(e.getMessage());
             } catch (Exception ex) {
                 throw new WebServerException(ex);
             }

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkLibrary.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkLibrary.java
@@ -34,7 +34,7 @@ public class MturkLibrary extends AbstractLibrary {
     public MturkLibrary(Properties properties, Survey survey) {
         init();
         this.props = properties;
-//        Runner.LOGGER.info("Updated properties to " + properties.toString());
+        Runner.LOGGER.info("Updated properties to " + properties.toString());
         this.props.setProperty("reward", Double.toString(Runner.basePay));
     }
 
@@ -68,11 +68,11 @@ public class MturkLibrary extends AbstractLibrary {
             File paramsFile = new File(AbstractLibrary.PARAMS);
             if (paramsFile.exists() && props==null){
                 props = new Properties();
-//                Runner.LOGGER.info("Loading properties from " + AbstractLibrary.PARAMS);
+                Runner.LOGGER.info("Loading properties from " + AbstractLibrary.PARAMS);
                 props.load(new FileReader(AbstractLibrary.PARAMS));
             } else {
-//                Runner.LOGGER.warn(String.format("%s exists: %b\n\tprops is null: %b",
-//                        AbstractLibrary.PARAMS, paramsFile.exists(), props==null));
+                Runner.LOGGER.warn(String.format("%s exists: %b\n\tprops is null: %b",
+                        AbstractLibrary.PARAMS, paramsFile.exists(), props==null));
             }
         } catch (FileNotFoundException fnfe) {
             fnfe.printStackTrace();
@@ -83,7 +83,7 @@ public class MturkLibrary extends AbstractLibrary {
                 props = new Properties();
         }
 
-//        Runner.LOGGER.info(props.toString());
+        Runner.LOGGER.info(props.toString());
 
         boolean sandbox = ! this.props.containsKey(Parameters.SANDBOX) ||
                 Boolean.parseBoolean(this.props.getProperty(Parameters.SANDBOX));
@@ -102,7 +102,7 @@ public class MturkLibrary extends AbstractLibrary {
         if (! cfile.exists() ) {
             if (alt.exists())
                 alt.renameTo(cfile);
-//            else Runner.LOGGER.warn("ERROR: You have not yet set up the surveyman directory nor AWS keys. Please see the project website for instructions.");
+            else Runner.LOGGER.warn("ERROR: You have not yet set up the surveyman directory nor AWS keys. Please see the project website for instructions.");
         } else {
             try {
                 // make sure we have both names for the access keys in the config file
@@ -134,7 +134,7 @@ public class MturkLibrary extends AbstractLibrary {
                     bw.close();
                 }
             } catch (IOException io){
-//                Runner.LOGGER.trace(io);
+                Runner.LOGGER.trace(io);
             }
         }
     }
@@ -162,13 +162,13 @@ public class MturkLibrary extends AbstractLibrary {
         if (o instanceof MturkLibrary) {
             MturkLibrary that = (MturkLibrary) o;
             if (!this.CONFIG.equals(that.CONFIG)) {
-//                LOGGER.debug(String.format("Config filenames are not equal (%s vs. %s)", this.CONFIG, that.CONFIG));
+                LOGGER.debug(String.format("Config filenames are not equal (%s vs. %s)", this.CONFIG, that.CONFIG));
                 return false;
             } else if (!this.EXTERNAL_HIT.equals(that.EXTERNAL_HIT)) {
-//                LOGGER.debug(String.format("External HIT URLs not equal (%s vs. %s)", this.EXTERNAL_HIT, that.EXTERNAL_HIT));
+                LOGGER.debug(String.format("External HIT URLs not equal (%s vs. %s)", this.EXTERNAL_HIT, that.EXTERNAL_HIT));
                 return false;
             } else if (!this.MTURK_URL.equals(that.MTURK_URL)) {
-//                LOGGER.debug(String.format("Mturk URLs not equal (%s vs. %s)", this.MTURK_URL, that.MTURK_URL));
+                LOGGER.debug(String.format("Mturk URLs not equal (%s vs. %s)", this.MTURK_URL, that.MTURK_URL));
                 return false;
             } else {
                 Set<String> thisBackendHeaders = new HashSet<String>(this.backendHeaders);
@@ -176,9 +176,9 @@ public class MturkLibrary extends AbstractLibrary {
                 if (thisBackendHeaders.equals(thatBackendHeaders))
                     return true;
                 else {
-//                    LOGGER.debug(String.format("Backend headers not equal (%s vs. %s)",
-//                            StringUtils.join(thisBackendHeaders, ","),
-//                            StringUtils.join(thatBackendHeaders, ",")));
+                    LOGGER.debug(String.format("Backend headers not equal (%s vs. %s)",
+                            StringUtils.join(thisBackendHeaders, ","),
+                            StringUtils.join(thatBackendHeaders, ",")));
                     return false;
                 }
             }

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkResponseManager.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkResponseManager.java
@@ -15,8 +15,6 @@ import edu.umass.cs.runner.system.backend.ITask;
 import edu.umass.cs.runner.system.Parameters;
 import edu.umass.cs.runner.system.SurveyResponse;
 import edu.umass.cs.surveyman.qc.QCMetrics;
-import edu.umass.cs.surveyman.qc.classifiers.EntropyClassifier;
-import edu.umass.cs.surveyman.qc.classifiers.LogLikelihoodClassifier;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import org.apache.logging.log4j.Logger;
@@ -37,7 +35,7 @@ public class MturkResponseManager extends AbstractResponseManager {
         }
     }
 
-//    private static final Logger LOGGER = Runner.LOGGER;
+    private static final Logger LOGGER = Runner.LOGGER;
     protected final PropertiesClientConfig config;
     protected final RequesterService service;
     final protected static long maxAutoApproveDelay = 2592000l;
@@ -58,7 +56,7 @@ public class MturkResponseManager extends AbstractResponseManager {
             int waittime)
     {
         if (waittime > MturkResponseManager.maxwaittime){
-//          LOGGER.warn(String.format("Wait time in %s has exceeded max wait time. Cancelling request.", name));
+          LOGGER.warn(String.format("Wait time in %s has exceeded max wait time. Cancelling request.", name));
           return true;
         } else return false;
     }
@@ -72,18 +70,18 @@ public class MturkResponseManager extends AbstractResponseManager {
             synchronized (service) {
                 try {
                     HIT hit = service.getHIT(taskId);
-//                    LOGGER.info(String.format("Retrieved HIT %s", hit.getHITId()));
+                    LOGGER.info(String.format("Retrieved HIT %s", hit.getHITId()));
                     return new MturkTask(hit);
                 } catch (InternalServiceException ise) {
                     if (overTime(name, waittime)) {
-//                        LOGGER.error(String.format("%s ran over time", name));
+                        LOGGER.error(String.format("%s ran over time", name));
                         return null;
                     }
-//                    LOGGER.warn(format("{0} {1}", name, ise));
+                    LOGGER.warn(format("{0} {1}", name, ise));
                     chill(waittime);
                     waittime *= 2;
                 } catch (ObjectDoesNotExistException odnee) {
-//                    LOGGER.warn(format("{0} {1}", name, odnee));
+                    LOGGER.warn(format("{0} {1}", name, odnee));
                 }
             }
         }
@@ -101,10 +99,10 @@ public class MturkResponseManager extends AbstractResponseManager {
                     List<Assignment> assignments = new LinkedList<Assignment>();
                     boolean addAll = assignments.addAll(Arrays.asList(hitAssignments));
                     if (addAll)
-//                        LOGGER.info(String.format("Retrieved %d assignments for HIT %s", hitAssignments.length, hit.getHITId()));
+                        LOGGER.info(String.format("Retrieved %d assignments for HIT %s", hitAssignments.length, hit.getHITId()));
                     return assignments;
                 } catch (InternalServiceException ise) {
-//                  LOGGER.warn(format("{0} {1}", name, ise));
+                  LOGGER.warn(format("{0} {1}", name, ise));
                   chill(waittime); 
                   waittime *= 2;
                 }
@@ -128,7 +126,7 @@ public class MturkResponseManager extends AbstractResponseManager {
                 service.extendHIT(taskId, maxAssignmentsIncrement, expirationIncrementMillis / 1000);
                 return true;
             } catch (InternalServiceException ise) {
-//                LOGGER.warn(format("{0} {1}", name, ise));
+                LOGGER.warn(format("{0} {1}", name, ise));
                 if (overTime(name, waitTime))
                     return false;
                 chill(waitTime);
@@ -148,25 +146,25 @@ public class MturkResponseManager extends AbstractResponseManager {
         while (true){
             try {
                 Record r = getRecord(survey);
-//                Runner.LOGGER.info("All tasks for this record:" + r.getAllTasks().length);
+                Runner.LOGGER.info("All tasks for this record:" + r.getAllTasks().length);
                 if (r.getAllTasks().length==0){
-//                    Runner.LOGGER.info("No tasks for record " + r.rid);
+                    Runner.LOGGER.info("No tasks for record " + r.rid);
                     return;
                 }
                 for (ITask task : r.getAllTasks()) {
                     Assignment[] assignments = service.getAllAssignmentsForHIT(task.getTaskId());
-//                    Runner.LOGGER.info("all assignments for this record:" + assignments.length);
+                    Runner.LOGGER.info("all assignments for this record:" + assignments.length);
                     String assignmentId = "";
                     for (Assignment a : assignments) {
                         if (a.getWorkerId().equals(sr.getSrid())) {
                             service.grantBonus(sr.getSrid(), amount, assignmentId, "For partial work completed.");
-//                            Runner.LOGGER.info(String.format("Granted worker %s bonus %f for assignment %s in survey %s"
-//                                    , sr.getSrid(), amount, assignmentId, survey.sourceName));
+                            Runner.LOGGER.info(String.format("Granted worker %s bonus %f for assignment %s in survey %s"
+                                    , sr.getSrid(), amount, assignmentId, survey.sourceName));
                         }
                     }
                 }
             } catch (InternalServiceException ise) {
-//                LOGGER.warn(format("{0} {1}", name, ise));
+                LOGGER.warn(format("{0} {1}", name, ise));
                 if (overTime(name, waitTime)){
 
                     return;
@@ -226,10 +224,10 @@ public class MturkResponseManager extends AbstractResponseManager {
                     service.forceExpireHIT(task.getTaskId());
                     return true;
                 }catch(InternalServiceException ise){
-//                  LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
+                  LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
                   chill(1);
                 }catch(ObjectDoesNotExistException odne) {
-//                  LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
+                  LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
                   return false;
                 }
             }
@@ -244,7 +242,7 @@ public class MturkResponseManager extends AbstractResponseManager {
                 try {
                     return service.getWebsiteURL();
                 } catch (InternalServiceException ise) {
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
                   chill(3); 
                 }
             }
@@ -265,7 +263,7 @@ public class MturkResponseManager extends AbstractResponseManager {
             throws ParseException,
             SurveyException
     {
-//        Runner.LOGGER.info("WebsiteURL:\t"+getWebsiteURL());
+        Runner.LOGGER.info("WebsiteURL:\t"+getWebsiteURL());
         System.out.println(getWebsiteURL());
         String name = "createHIT";
         int waittime = 1;
@@ -289,7 +287,7 @@ public class MturkResponseManager extends AbstractResponseManager {
                     return hitid.getHITId();
                 } catch (InternalServiceException ise) {
                     String info = MessageFormat.format("{0} {1}", name, ise);
-//                    LOGGER.info(info);
+                    LOGGER.info(info);
                     System.out.println(info);
                     if (overTime(name, waittime)) {
                       throw new CreateHITException(title);
@@ -297,7 +295,7 @@ public class MturkResponseManager extends AbstractResponseManager {
                     chill(waittime);
                     waittime *= 2;
                 } catch (ObjectAlreadyExistsException e) {
-//                    LOGGER.info(MessageFormat.format("{0} {1}", name, e));
+                    LOGGER.info(MessageFormat.format("{0} {1}", name, e));
                     chill(waittime);
                     waittime *= 2;
                 }
@@ -328,10 +326,10 @@ public class MturkResponseManager extends AbstractResponseManager {
                     HIT hit = service.getHIT(task.getTaskId());
                     return hit.getNumberOfAssignmentsAvailable();
                 }catch(InternalServiceException ise){
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
                     chill(1);
                 }catch(ObjectDoesNotExistException odne) {
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
                     return 0;
                 }
             }
@@ -348,18 +346,18 @@ public class MturkResponseManager extends AbstractResponseManager {
                     service.extendHIT(id, n, minExpirationIncrementInSeconds);
                     return task;
                 }catch(InternalServiceException ise){
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", name, ise));
                     if (waittime > maxWaitTimeInSeconds) {
                         String msg = String.format("WARNING: Exceeded max wait time in %s.%s..."
                                 , name.getEnclosingClass().getName()
                                 , name.getEnclosingMethod().getName());
-//                        LOGGER.warn(msg);
+                        LOGGER.warn(msg);
                         System.err.println(msg);
                     }
                     chill(waittime);
                     waittime *= 2;
                 }catch(ObjectDoesNotExistException odne) {
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", name, odne));
                     return null;
                 }
             }
@@ -379,13 +377,13 @@ public class MturkResponseManager extends AbstractResponseManager {
                         String msg = String.format("WARNING: Exceeded max wait time in %s.%s..."
                                 , clz.getEnclosingClass().getName()
                                 , clz.getEnclosingMethod().getName());
-//                        LOGGER.warn(msg);
+                        LOGGER.warn(msg);
                         System.err.println(msg);
                     }
                     chill(waittime);
                     waittime *= 2;
                 } catch(ObjectDoesNotExistException odne) {
-//                    LOGGER.warn(MessageFormat.format("{0} {1}", clz, odne));
+                    LOGGER.warn(MessageFormat.format("{0} {1}", clz, odne));
                     return false;
                 }
             }
@@ -397,12 +395,26 @@ public class MturkResponseManager extends AbstractResponseManager {
             Record record)
             throws SurveyException
     {
-        String classname = record.classifier.getClass().getName();
-        if (classname.equals(LogLikelihoodClassifier.class.getName()))
-                return record.classifier.classifyResponse(surveyResponse);
-        else if (classname.equals(EntropyClassifier.class.getName()))
-                return record.classifier.classifyResponse(surveyResponse);
-        else throw new RuntimeException("Unknown classifier: "+classname);
+        switch (record.classifier) {
+            case LOG_LIKELIHOOD:
+                return QCMetrics.logLikelihoodClassification(
+                        record.survey,
+                        surveyResponse,
+                        new ArrayList<SurveyResponse>(record.getAllResponses()),
+                        record.smoothing,
+                        record.alpha
+                );
+            case ENTROPY:
+                return QCMetrics.entropyClassification(
+                        record.survey,
+                        surveyResponse,
+                        new ArrayList<SurveyResponse>(record.getAllResponses()),
+                        record.smoothing,
+                        record.alpha
+                );
+            default:
+                throw new RuntimeException("Unknown classifier: "+record.classifier);
+        }
     }
 
     public int addResponses(
@@ -434,7 +446,7 @@ public class MturkResponseManager extends AbstractResponseManager {
                         SurveyResponse sr = parseResponse(a.getWorkerId(), a.getAnswer(), survey, record, otherValues);
                         assert !sr.otherValues.isEmpty();
                         boolean valid = isValid(sr, record);
-//                        LOGGER.debug(String.format("Response %s valid: %b", sr.getSrid(), valid));
+                        LOGGER.debug(String.format("Response %s valid: %b", sr.getSrid(), valid));
                         assert valid == (sr.getScore() >= sr.getThreshold());
                         if (valid) {
                             record.addValidResponse(sr);
@@ -451,9 +463,9 @@ public class MturkResponseManager extends AbstractResponseManager {
             }
             success=true;
         }
-//        if (validResponsesToAdd>0 || botResponsesToAdd> 0)
-//            LOGGER.info(String.format("%d responses total. %d valid responses added. %d invalid responses added."
-//                    , record.getNumValidResponses()+record.getNumBotResponses(), validResponsesToAdd, botResponsesToAdd));
+        if (validResponsesToAdd>0 || botResponsesToAdd> 0)
+            LOGGER.info(String.format("%d responses total. %d valid responses added. %d invalid responses added."
+                    , record.getNumValidResponses()+record.getNumBotResponses(), validResponsesToAdd, botResponsesToAdd));
         return validResponsesToAdd;
     }
 }

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkSurveyPoster.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkSurveyPoster.java
@@ -35,7 +35,7 @@ public class MturkSurveyPoster implements ISurveyPoster {
         HIT hit = ((MturkTask) mturkTask).hit;
         String url = ((MturkResponseManager) responseManager).getWebsiteURL()+"/mturk/preview?groupId="+hit.getHITTypeId();
         if (urlnotLogged) {
-//            Runner.LOGGER.info(url);
+            Runner.LOGGER.info(url);
             urlnotLogged = false;
         }
         return url;
@@ -54,7 +54,7 @@ public class MturkSurveyPoster implements ISurveyPoster {
                     props.getProperty(Parameters.TITLE)
                     , props.getProperty(Parameters.DESCRIPTION)
                     , props.getProperty(Parameters.KEYWORDS)
-                    , MturkXML.getXMLString(record.qcMetrics)
+                    , MturkXML.getXMLString(record.survey)
                     , Double.parseDouble(props.getProperty(Parameters.REWARD))
                     , Long.parseLong(props.getProperty(Parameters.ASSIGNMENT_DURATION))
                     , MturkResponseManager.maxAutoApproveDelay

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkSurveyPoster.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/MturkSurveyPoster.java
@@ -54,7 +54,7 @@ public class MturkSurveyPoster implements ISurveyPoster {
                     props.getProperty(Parameters.TITLE)
                     , props.getProperty(Parameters.DESCRIPTION)
                     , props.getProperty(Parameters.KEYWORDS)
-                    , MturkXML.getXMLString(record.survey)
+                    , MturkXML.getXMLString(record.qcMetrics)
                     , Double.parseDouble(props.getProperty(Parameters.REWARD))
                     , Long.parseLong(props.getProperty(Parameters.ASSIGNMENT_DURATION))
                     , MturkResponseManager.maxAutoApproveDelay

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/generators/MturkXML.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/generators/MturkXML.java
@@ -5,6 +5,7 @@ import edu.umass.cs.runner.Record;
 import edu.umass.cs.runner.system.generators.HTML;
 import edu.umass.cs.runner.system.backend.known.mturk.MturkLibrary;
 import edu.umass.cs.runner.utils.Slurpie;
+import edu.umass.cs.surveyman.qc.QCMetrics;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 
@@ -13,11 +14,11 @@ import java.io.*;
 public class MturkXML {
 
     public static final int maxQuestionXMLLength = 131072;
-    
-    public static String getXMLString(Survey survey) throws SurveyException {
+
+    public static String getXMLString(QCMetrics qcMetrics) throws SurveyException {
         String retval;
         try {
-            Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
+            Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
             retval = String.format(Slurpie.slurp(MturkLibrary.XMLSKELETON), HTML.getHTMLString(record, new MturkHTML()));
             if (retval.length() > maxQuestionXMLLength)
                 throw new MaxXMLLengthException(retval.length());

--- a/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/generators/MturkXML.java
+++ b/src/main/java/edu/umass/cs/runner/system/backend/known/mturk/generators/MturkXML.java
@@ -5,7 +5,6 @@ import edu.umass.cs.runner.Record;
 import edu.umass.cs.runner.system.generators.HTML;
 import edu.umass.cs.runner.system.backend.known.mturk.MturkLibrary;
 import edu.umass.cs.runner.utils.Slurpie;
-import edu.umass.cs.surveyman.qc.QCMetrics;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 
@@ -15,10 +14,10 @@ public class MturkXML {
 
     public static final int maxQuestionXMLLength = 131072;
     
-    public static String getXMLString(QCMetrics qcMetrics) throws SurveyException {
+    public static String getXMLString(Survey survey) throws SurveyException {
         String retval;
         try {
-            Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
+            Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
             retval = String.format(Slurpie.slurp(MturkLibrary.XMLSKELETON), HTML.getHTMLString(record, new MturkHTML()));
             if (retval.length() > maxQuestionXMLLength)
                 throw new MaxXMLLengthException(retval.length());

--- a/src/main/java/edu/umass/cs/runner/system/generators/HTML.java
+++ b/src/main/java/edu/umass/cs/runner/system/generators/HTML.java
@@ -57,7 +57,7 @@ public class HTML {
             IllegalAccessException
     {
         String htmlFileName = Record.getHtmlFileName(survey);
-//        Runner.LOGGER.info(String.format("Source html found at %s", htmlFileName));
+        Runner.LOGGER.info(String.format("Source html found at %s", htmlFileName));
         BufferedWriter bw = new BufferedWriter(new FileWriter(htmlFileName));
         bw.write(html);
         bw.close();
@@ -98,16 +98,16 @@ public class HTML {
                     , Slurpie.slurp(AbstractLibrary.CUSTOMCSS, true)
             );
         } catch (FileNotFoundException ex) {
-//            Runner.LOGGER.fatal(ex);
+            Runner.LOGGER.fatal(ex);
             System.exit(-1);
         } catch (IOException ex) {
-//            Runner.LOGGER.fatal(ex);
+            Runner.LOGGER.fatal(ex);
             System.exit(-1);
         }
         try{
             spitHTMLToFile(html, record.survey);
         } catch (IOException io) {
-//            Runner.LOGGER.warn(io);
+            Runner.LOGGER.warn(io);
         } catch (InstantiationException e) {
             e.printStackTrace();
         } catch (IllegalAccessException e) {

--- a/src/main/java/edu/umass/cs/runner/system/job/JobManager.java
+++ b/src/main/java/edu/umass/cs/runner/system/job/JobManager.java
@@ -45,7 +45,7 @@ public class JobManager {
         for (String line : data.split("\n")){
             String[] pieces = line.split(",");
             if (pieces[0].equals(sr.getSrid()) && pieces[1].equals(survey.sourceName)) {
-//                Runner.LOGGER.info("BONUS PAID for response with id " + sr.getSrid());
+                Runner.LOGGER.info("BONUS PAID for response with id " + sr.getSrid());
                 return true;
             }
         }
@@ -92,7 +92,7 @@ public class JobManager {
             dump(AbstractLibrary.UNFINISHED_JOB_FILE, data.toString());
             return true;
         } catch (IOException ex) {
-//            Runner.LOGGER.warn(ex);
+            Runner.LOGGER.warn(ex);
         }
         return false;
     }
@@ -116,7 +116,7 @@ public class JobManager {
             dump(dir + jobID + ".csv", Slurpie.slurp(survey.source));
             return true;
         } catch (IOException ex) {
-//            Runner.LOGGER.warn(ex);
+            Runner.LOGGER.warn(ex);
         }
         return false;
     }
@@ -146,11 +146,11 @@ public class JobManager {
         record.outputFileName = AbstractLibrary.OUTDIR + AbstractLibrary.fileSep + jobId + ".csv";
         try {
             String[] responses = Slurpie.slurp(record.outputFileName).split("\n");
-//            Runner.LOGGER.info(record.outputFileName);
+            Runner.LOGGER.info(record.outputFileName);
             SurveyResponse sr = new SurveyResponse(record.survey, "");
             sr.readSurveyResponses(record.survey, new FileReader(record.outputFileName));
         } catch (IOException io) {
-//            Runner.LOGGER.info(io);
+            Runner.LOGGER.info(io);
         }
     }
 
@@ -203,7 +203,7 @@ public class JobManager {
             }
             JobManager.dump(AbstractLibrary.UNFINISHED_JOB_FILE, writeMe.toString(), false);
         } catch (IOException ex) {
-//            Runner.LOGGER.warn(ex);
+            Runner.LOGGER.warn(ex);
         }
     }
 }

--- a/src/test/java/edu/umass/cs/runner/MTurkTest.java
+++ b/src/test/java/edu/umass/cs/runner/MTurkTest.java
@@ -10,6 +10,7 @@ import edu.umass.cs.runner.system.backend.known.mturk.MturkResponseManager;
 import edu.umass.cs.runner.system.backend.known.mturk.MturkSurveyPoster;
 import edu.umass.cs.surveyman.input.csv.CSVLexer;
 import edu.umass.cs.surveyman.input.csv.CSVParser;
+import edu.umass.cs.surveyman.qc.QCMetrics;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import org.junit.Test;
@@ -46,7 +47,8 @@ public class MTurkTest extends TestLog {
         CSVParser parser = new CSVParser(new CSVLexer(testsFiles[i], String.valueOf(separators[i])));
         Survey survey = parser.parse();
         MturkLibrary lib = new MturkLibrary();
-        Record record = new Record(survey, lib, KnownBackendType.MTURK);
+        QCMetrics qcMetrics = new QCMetrics(survey, null);
+        Record record = new Record(qcMetrics, lib, KnownBackendType.MTURK);
         AbstractResponseManager responseManager = new MturkResponseManager(lib);
         ISurveyPoster surveyPoster = new MturkSurveyPoster();
         record.library.props.setProperty("hitlifetime", "3000");

--- a/src/test/java/edu/umass/cs/runner/MTurkTest.java
+++ b/src/test/java/edu/umass/cs/runner/MTurkTest.java
@@ -10,7 +10,6 @@ import edu.umass.cs.runner.system.backend.known.mturk.MturkResponseManager;
 import edu.umass.cs.runner.system.backend.known.mturk.MturkSurveyPoster;
 import edu.umass.cs.surveyman.input.csv.CSVLexer;
 import edu.umass.cs.surveyman.input.csv.CSVParser;
-import edu.umass.cs.surveyman.qc.QCMetrics;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import org.junit.Test;
@@ -47,8 +46,7 @@ public class MTurkTest extends TestLog {
         CSVParser parser = new CSVParser(new CSVLexer(testsFiles[i], String.valueOf(separators[i])));
         Survey survey = parser.parse();
         MturkLibrary lib = new MturkLibrary();
-        QCMetrics qcMetrics = new QCMetrics(survey, null);
-        Record record = new Record(qcMetrics, lib, KnownBackendType.MTURK);
+        Record record = new Record(survey, lib, KnownBackendType.MTURK);
         AbstractResponseManager responseManager = new MturkResponseManager(lib);
         ISurveyPoster surveyPoster = new MturkSurveyPoster();
         record.library.props.setProperty("hitlifetime", "3000");

--- a/src/test/java/edu/umass/cs/runner/SystemTest.java
+++ b/src/test/java/edu/umass/cs/runner/SystemTest.java
@@ -80,7 +80,7 @@ public class SystemTest extends TestLog {
                 RandomRespondent rr = new RandomRespondent(survey, RandomRespondent.AdversaryType.UNIFORM);
                 String headers = ResponseWriter.outputHeaders(survey, new ArrayList<String>());
                 String output = ResponseWriter.outputSurveyResponse(survey,
-                        new SurveyResponse(new SurveyResponse(rr.getResponse())));
+                        new SurveyResponse(rr.getResponse()));
                 new SurveyResponse(survey, "").readSurveyResponses(survey, new StringReader(headers + output));
             } catch (SurveyException se) {
                 if (super.outcome[i])

--- a/src/test/java/edu/umass/cs/runner/SystemTest.java
+++ b/src/test/java/edu/umass/cs/runner/SystemTest.java
@@ -8,12 +8,11 @@ import edu.umass.cs.runner.system.backend.known.mturk.generators.MturkXML;
 import edu.umass.cs.runner.system.generators.HTML;
 import edu.umass.cs.surveyman.input.csv.CSVLexer;
 import edu.umass.cs.surveyman.input.csv.CSVParser;
-import edu.umass.cs.surveyman.qc.QCMetrics;
-import edu.umass.cs.surveyman.qc.classifiers.AllClassifier;
-import edu.umass.cs.surveyman.qc.respondents.RandomRespondent;
+import edu.umass.cs.surveyman.qc.RandomRespondent;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import junit.framework.Assert;
+import org.apache.commons.lang.ObjectUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -39,8 +38,7 @@ public class SystemTest extends TestLog {
                 CSVParser csvParser = new CSVParser(new CSVLexer(testsFiles[i], String.valueOf(separators[i])));
                 Survey survey = csvParser.parse();
                 MturkLibrary.dumpSampleProperties();
-                QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
-                Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
+                Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
                 HTML.getHTMLString(record, new MturkHTML());
                 LOGGER.info(testsFiles[i]+" generated IHTML successfully.");
             }
@@ -56,9 +54,7 @@ public class SystemTest extends TestLog {
             for (int i = 0 ; i < testsFiles.length ; i++) {
                 currentFile = testsFiles[i];
                 CSVParser csvParser = new CSVParser(new CSVLexer(currentFile, String.valueOf(separators[i])));
-                Survey survey = csvParser.parse();
-                QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
-                MturkXML.getXMLString(qcMetrics);
+                MturkXML.getXMLString(csvParser.parse());
                 LOGGER.info(testsFiles[i]+" generated IHTML successfully.");
             }
         } catch (SurveyException se) {
@@ -80,7 +76,7 @@ public class SystemTest extends TestLog {
                 RandomRespondent rr = new RandomRespondent(survey, RandomRespondent.AdversaryType.UNIFORM);
                 String headers = ResponseWriter.outputHeaders(survey, new ArrayList<String>());
                 String output = ResponseWriter.outputSurveyResponse(survey,
-                        new SurveyResponse(new SurveyResponse(rr.getResponse())));
+                        new SurveyResponse((SurveyResponse) rr.getResponse()));
                 new SurveyResponse(survey, "").readSurveyResponses(survey, new StringReader(headers + output));
             } catch (SurveyException se) {
                 if (super.outcome[i])
@@ -102,8 +98,7 @@ public class SystemTest extends TestLog {
         CSVParser csvParser = new CSVParser(new CSVLexer(testsFiles[0], String.valueOf(separators[0])));
         Survey survey = csvParser.parse();
         MturkLibrary.dumpSampleProperties();
-        QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
-        Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
+        Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
         String serializedFileName = record.serializeRecord();
         Record deserializedRecord = Record.deserializeRecord(serializedFileName);
         try {

--- a/src/test/java/edu/umass/cs/runner/SystemTest.java
+++ b/src/test/java/edu/umass/cs/runner/SystemTest.java
@@ -8,11 +8,12 @@ import edu.umass.cs.runner.system.backend.known.mturk.generators.MturkXML;
 import edu.umass.cs.runner.system.generators.HTML;
 import edu.umass.cs.surveyman.input.csv.CSVLexer;
 import edu.umass.cs.surveyman.input.csv.CSVParser;
-import edu.umass.cs.surveyman.qc.RandomRespondent;
+import edu.umass.cs.surveyman.qc.QCMetrics;
+import edu.umass.cs.surveyman.qc.classifiers.AllClassifier;
+import edu.umass.cs.surveyman.qc.respondents.RandomRespondent;
 import edu.umass.cs.surveyman.survey.Survey;
 import edu.umass.cs.surveyman.survey.exceptions.SurveyException;
 import junit.framework.Assert;
-import org.apache.commons.lang.ObjectUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -38,7 +39,8 @@ public class SystemTest extends TestLog {
                 CSVParser csvParser = new CSVParser(new CSVLexer(testsFiles[i], String.valueOf(separators[i])));
                 Survey survey = csvParser.parse();
                 MturkLibrary.dumpSampleProperties();
-                Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
+                QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
+                Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
                 HTML.getHTMLString(record, new MturkHTML());
                 LOGGER.info(testsFiles[i]+" generated IHTML successfully.");
             }
@@ -54,7 +56,9 @@ public class SystemTest extends TestLog {
             for (int i = 0 ; i < testsFiles.length ; i++) {
                 currentFile = testsFiles[i];
                 CSVParser csvParser = new CSVParser(new CSVLexer(currentFile, String.valueOf(separators[i])));
-                MturkXML.getXMLString(csvParser.parse());
+                Survey survey = csvParser.parse();
+                QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
+                MturkXML.getXMLString(qcMetrics);
                 LOGGER.info(testsFiles[i]+" generated IHTML successfully.");
             }
         } catch (SurveyException se) {
@@ -76,7 +80,7 @@ public class SystemTest extends TestLog {
                 RandomRespondent rr = new RandomRespondent(survey, RandomRespondent.AdversaryType.UNIFORM);
                 String headers = ResponseWriter.outputHeaders(survey, new ArrayList<String>());
                 String output = ResponseWriter.outputSurveyResponse(survey,
-                        new SurveyResponse((SurveyResponse) rr.getResponse()));
+                        new SurveyResponse(new SurveyResponse(rr.getResponse())));
                 new SurveyResponse(survey, "").readSurveyResponses(survey, new StringReader(headers + output));
             } catch (SurveyException se) {
                 if (super.outcome[i])
@@ -98,7 +102,8 @@ public class SystemTest extends TestLog {
         CSVParser csvParser = new CSVParser(new CSVLexer(testsFiles[0], String.valueOf(separators[0])));
         Survey survey = csvParser.parse();
         MturkLibrary.dumpSampleProperties();
-        Record record = new Record(survey, new MturkLibrary(), KnownBackendType.MTURK);
+        QCMetrics qcMetrics = new QCMetrics(survey, new AllClassifier(survey));
+        Record record = new Record(qcMetrics, new MturkLibrary(), KnownBackendType.MTURK);
         String serializedFileName = record.serializeRecord();
         Record deserializedRecord = Record.deserializeRecord(serializedFileName);
         try {


### PR DESCRIPTION
@etosch - With this commit the build issues seem to be fixed, as are
the logging problems (fixed by pinning some stuff in the pom).  I
reverted your commit that commented out the logging (since it is now
working again), and pulled out the non-logging changes from that
commit into a fresh commit.

There are still test failures - one of which seems legit:

```
testSerialize(edu.umass.cs.runner.SystemTest)  Time elapsed: 0.182 sec  <<< ERROR!
java.io.NotSerializableException: edu.umass.cs.surveyman.qc.classifiers.AllClassifier
```

There are a bunch of fields in Record that don't implement
`Serializable`, including AbstractClassifier, QCMetrics and
SurveyResponse (some of which are from the main SurveyMan project).  I
can open up PRs to make them serializable if that sounds good?  Maybe
there is another way this is supposed to work, or maybe this is
something that broke with the switch from targeting java 1.5 -> java
7?

The other error is:

```
java.lang.AssertionError: Sample size cannot be less than 0: 0
at edu.umass.cs.surveyman.qc.QCMetrics.<init>(QCMetrics.java:83)
at edu.umass.cs.runner.SystemTest.testXMLGenerator(SystemTest.java:60)
```

Going to look at this now, but I'll open up a second PR if I figure it
out.